### PR TITLE
feat: implements Sha256 + Salt encryptation for password

### DIFF
--- a/backend/src/main/java/br/com/backend/backend/Exceptions/Custom/AccountNotFoundException.java
+++ b/backend/src/main/java/br/com/backend/backend/Exceptions/Custom/AccountNotFoundException.java
@@ -1,0 +1,7 @@
+package br.com.backend.backend.Exceptions.Custom;
+
+public class AccountNotFoundException  extends ResourceNotFoundException{
+    public AccountNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/br/com/backend/backend/Exceptions/GlobalExceptionHandler.java
+++ b/backend/src/main/java/br/com/backend/backend/Exceptions/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import br.com.backend.backend.DTOs.ResultViewModel;
 import br.com.backend.backend.Exceptions.Custom.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -13,7 +14,18 @@ import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-    
+
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<ResultViewModel<Void>> handleBadCredentialsException(
+            BadCredentialsException ex
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ResultViewModel.error(
+                        List.of(ex.getMessage())
+                ));
+    }
+
     @ExceptionHandler(ResourceNotFoundException.class)
     public ResponseEntity<ResultViewModel<Void>> handleResourceNotFound(
             ResourceNotFoundException ex

--- a/backend/src/main/java/br/com/backend/backend/Security/Encode/Sha256SaltPasswordEncoder.java
+++ b/backend/src/main/java/br/com/backend/backend/Security/Encode/Sha256SaltPasswordEncoder.java
@@ -1,0 +1,50 @@
+package br.com.backend.backend.Security.Encode;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+public class Sha256SaltPasswordEncoder implements PasswordEncoder {
+    private static final int SALT_LENGTH = 16;
+
+    @Override
+    public String encode(CharSequence rawPassword) {
+        byte[] salt = generateSalt();
+        String saltBase64 = Base64.getEncoder().encodeToString(salt);
+        String hash = hashWithSalt(rawPassword.toString(), salt);
+        return saltBase64 + ":" + hash;
+    }
+
+    @Override
+    public boolean matches(CharSequence rawPassword, String storedPassword) {
+        String[] parts = storedPassword.split(":");
+        if (parts.length != 2) {
+            return false;
+        }
+
+        byte[] salt = Base64.getDecoder().decode(parts[0]);
+        String hashToCompare = hashWithSalt(rawPassword.toString(), salt);
+        return hashToCompare.equals(parts[1]);
+    }
+
+    private String hashWithSalt(String password, byte[] salt) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            md.update(salt);
+            byte[] hashed = md.digest(password.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(hashed);
+        } catch (Exception e) {
+            throw new RuntimeException("Erro ao gerar hash SHA-256", e);
+        }
+    }
+
+    private byte[] generateSalt() {
+        SecureRandom random = new SecureRandom();
+        byte[] salt = new byte[SALT_LENGTH];
+        random.nextBytes(salt);
+        return salt;
+    }
+}

--- a/backend/src/main/java/br/com/backend/backend/Security/SecurityConfig.java
+++ b/backend/src/main/java/br/com/backend/backend/Security/SecurityConfig.java
@@ -1,24 +1,20 @@
 package br.com.backend.backend.Security;
 
+import br.com.backend.backend.Security.Encode.Sha256SaltPasswordEncoder;
 import br.com.backend.backend.Security.auth.JwtAuthFilter;
-import br.com.backend.backend.Security.auth.JwtUtils;
-import br.com.backend.backend.Services.AccountService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -82,6 +78,6 @@ public class SecurityConfig {
 
     @Bean
     public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
+        return new Sha256SaltPasswordEncoder();
     }
 }

--- a/backend/src/main/java/br/com/backend/backend/Services/AccountService.java
+++ b/backend/src/main/java/br/com/backend/backend/Services/AccountService.java
@@ -4,6 +4,7 @@ import br.com.backend.backend.DTOs.Account.AccountDTO;
 import br.com.backend.backend.DTOs.Account.CreateAccountDTO;
 import br.com.backend.backend.Entities.Account;
 import br.com.backend.backend.Exceptions.Custom.AccountAlreadyExists;
+import br.com.backend.backend.Exceptions.Custom.AccountNotFoundException;
 import br.com.backend.backend.Repositories.AccountRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -19,11 +20,11 @@ public class AccountService {
     private final PasswordEncoder passwordEncoder;
 
     public Account getByEmail(String email) {
-        return accountRepository.findByEmail(email).orElseThrow(() -> new RuntimeException("Account not found"));
+        return accountRepository.findByEmail(email).orElseThrow(() -> new AccountNotFoundException("Account wiht email not found"));
     }
 
     public Account getById(Integer id) {
-        return accountRepository.findById(id).orElseThrow(() -> new RuntimeException("Account not found"));
+        return accountRepository.findById(id).orElseThrow(() -> new AccountNotFoundException("Account wiht id not found"));
     }
 
     public AccountDTO create(CreateAccountDTO dto) {


### PR DESCRIPTION
# Refactor: Implementação de hash SHA-256 + SALT para senhas

## O que foi feito

- Substituído o uso do `BCryptPasswordEncoder` por uma nova implementação de `PasswordEncoder` utilizando **SHA-256 com SALT aleatório**.
- O `salt` é gerado dinamicamente com `SecureRandom`, codificado em Base64, e armazenado junto ao hash no formato:  
- Implementada classe `Sha256PasswordEncoder` com os métodos `encode()` e `matches()` respeitando o padrão do Spring Security.

## GlobalExceptionHandler

- Handler de AccountNotFoundException
- Handler de BadCredentialsException